### PR TITLE
Add Apple ID login endpoint

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -238,3 +238,9 @@ class UserListSerializer(serializers.ModelSerializer):
     def get_following_count(self, obj):
         return Follow.objects.filter(follower=obj).count()
 
+
+class AppleLoginSerializer(serializers.Serializer):
+    """Apple ID ログイン用シリアライザー"""
+    identity_token = serializers.CharField()
+    username = serializers.CharField(required=False, allow_blank=True)
+

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -7,15 +7,24 @@ from rest_framework_simplejwt.views import (
     TokenRefreshView,
 )
 from .views import (
-    RegisterView, LoginView, UserProfileView, 
-    FollowView, NotificationView, FollowStatusView,
-    FollowersListView, FollowingListView, AccountDeleteView,
-    BlockUserView, BlockedUsersListView
+    RegisterView,
+    LoginView,
+    AppleLoginView,
+    UserProfileView,
+    FollowView,
+    NotificationView,
+    FollowStatusView,
+    FollowersListView,
+    FollowingListView,
+    AccountDeleteView,
+    BlockUserView,
+    BlockedUsersListView,
 )
 
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='register'),
     path('login/', LoginView.as_view(), name='login'),
+    path('apple-login/', AppleLoginView.as_view(), name='apple-login'),
     # simplejwt のトークン取得・リフレッシュ用エンドポイントを追加
     path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -1,0 +1,31 @@
+import requests
+from jose import jwt
+
+APPLE_KEYS_URL = "https://appleid.apple.com/auth/keys"
+
+_cached_keys = None
+
+def _fetch_apple_public_keys():
+    global _cached_keys
+    if _cached_keys is not None:
+        return _cached_keys
+    resp = requests.get(APPLE_KEYS_URL)
+    resp.raise_for_status()
+    _cached_keys = resp.json().get("keys", [])
+    return _cached_keys
+
+def verify_apple_identity_token(token, audience):
+    """Verify Apple identity token and return claims."""
+    keys = _fetch_apple_public_keys()
+    header = jwt.get_unverified_header(token)
+    kid = header.get("kid")
+    key = next((k for k in keys if k.get("kid") == kid), None)
+    if not key:
+        raise ValueError("Public key not found for Apple token")
+    return jwt.decode(
+        token,
+        key,
+        algorithms=["RS256"],
+        audience=audience,
+        issuer="https://appleid.apple.com",
+    )


### PR DESCRIPTION
## Summary
- add Apple ID token verification helper
- support Apple ID login via new endpoint

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6862aeba0fd88327a78e82a48b621953