### PR TITLE
Fix profile image URL not reflected

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -32,8 +32,8 @@ class UserSerializer(serializers.ModelSerializer):
         if obj.profile_image and hasattr(obj.profile_image, 'url'):
             request = self.context.get('request')
             if request:
-                # 修正点: build_absolute_url ではなく build_absolute_uri を使用
-                return request.build_absolute_uri(obj.profile_image_url)
+                return request.build_absolute_uri(obj.profile_image.url)
+            return obj.profile_image.url
         return None
 
     def get_is_blocked_by_me(self, obj):
@@ -45,17 +45,10 @@ class UserSerializer(serializers.ModelSerializer):
 
     def get_am_i_blocked(self, obj):
         request = self.context.get('request')
-        print(f"--- Debug: get_am_i_blocked ---")
-        print(f"    Profile User (obj.id): {obj.id}")
         if request and request.user.is_authenticated:
-            print(f"    Request User (request.user.id): {request.user.id}")
             # blocker=プロフィール対象ユーザー, blocked=リクエストユーザー で検索
-            exists = Block.objects.filter(blocker=obj, blocked=request.user).exists()
-            print(f"    Block record exists (blocker={obj.id}, blocked={request.user.id}): {exists}")
-            return exists
-        else:
-            print(f"    Request user not authenticated or request context missing.")
-            return False
+            return Block.objects.filter(blocker=obj, blocked=request.user).exists()
+        return False
 
     def get_is_following(self, obj):
         request = self.context.get('request')

--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -13,9 +13,14 @@ class UserBriefSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ['id', 'username', 'profile_image_url', 'bio']
-    
+
     def get_profile_image_url(self, obj):
-        return obj.profile_image_url
+        if obj.profile_image and hasattr(obj.profile_image, 'url'):
+            request = self.context.get('request')
+            if request:
+                return request.build_absolute_uri(obj.profile_image.url)
+            return obj.profile_image.url
+        return None
 
 class PostSerializer(serializers.ModelSerializer):
     """投稿シリアライザー（YAML仕様準拠：snake_caseフィールド）"""


### PR DESCRIPTION
## Summary
- Ensure user profile image URLs use absolute paths
- Return absolute profile image URLs in post user data
- Remove debug logging from user serializer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b256288883279b7a6f25dc130a81